### PR TITLE
Use system perl or no-op on windows 

### DIFF
--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -5,6 +5,21 @@ function dvisvg()
     return DVISVGM_PATH[]
 end
 
+# Since perl_jll doesn't build for windows we check this.
+# todo define the function in a static block
+function mtperl(f)
+    @static if Sys.iswindows() || isnothing(find(:perl, propertynames(Perl_jll)))
+        if isnothing(Sys.which("perl"))
+            @warn "Perl not found!  Skipping cropping step"
+            return
+        else
+            f(`perl`)
+        end
+    else
+        Perl_jll.perl(f)
+    end
+end
+
 
 # The main compilation method - compiles arbitrary LaTeX documents
 function compile_latex(
@@ -90,7 +105,7 @@ function compile_latex(
                     redirect_stderr(devnull) do
                         redirect_stdout(devnull) do
                             Ghostscript_jll.gs() do gs_exe
-                                Perl_jll.perl() do perl_exe
+                                mtperl() do perl_exe
                                     run(`$perl_exe $pdfcrop --margin $crop_margins $() --gscmd $gs_exe temp.pdf temp_cropped.pdf`)
                                 end
                             end

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -7,17 +7,17 @@ end
 
 # Since perl_jll doesn't build for windows we check this.
 # todo define the function in a static block
-function mtperl(f)
-    @static if Sys.iswindows() || !hasproperty(Perl_jll, :perl)
+@static if Sys.iswindows() # !hasproperty(Perl_jll, :perl)
         if isnothing(Sys.which("perl"))
             @warn "Perl not found!  Skipping cropping step"
-            return
+            mtperl(f) = identity(f)
         else
-            f(`perl`)
+            function mtperl(f)
+                    f(`perl`)
+            end
         end
-    else
-        Perl_jll.perl(f)
-    end
+else
+    mtperl(f) = Perl_jll.perl(f)
 end
 
 

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -8,7 +8,7 @@ end
 # Since perl_jll doesn't build for windows we check this.
 # todo define the function in a static block
 function mtperl(f)
-    @static if Sys.iswindows() || isnothing(find(:perl, propertynames(Perl_jll)))
+    @static if Sys.iswindows() || !hasproperty(Perl_jll, :perl)
         if isnothing(Sys.which("perl"))
             @warn "Perl not found!  Skipping cropping step"
             return


### PR DESCRIPTION
It was reported on Slack that MakieTeX doesn't work on windows, since Perl_jll doesn't build for that.  This PR works around that by using system perl if it exists, or just skipping it if it doesn't. 