### PR TITLE
Fix a Makie master issue

### DIFF
--- a/src/MakieTeX.jl
+++ b/src/MakieTeX.jl
@@ -8,6 +8,9 @@ using Base64
 
 # Patch for Makie.jl `@Block` macro error
 using Makie: CURRENT_DEFAULT_THEME
+if :make_block_docstring in names(Makie; all = true)
+    @eval import Makie: make_block_docstring
+end
 
 using Makie.GeometryBasics: origin, widths
 using Makie.Observables


### PR DESCRIPTION
Pull in the Makie define block docstring method if it does not already exist